### PR TITLE
Fetch names of BEAM files from source files

### DIFF
--- a/plugins.mk
+++ b/plugins.mk
@@ -25,7 +25,8 @@ LFE_FILES = $(sort $(call core_find,src/,*.lfe))
 
 ifneq ($(LFE_FILES),)
 
-BEAM_FILES += $(addprefix ebin/,$(patsubst %.lfe,%.beam,$(notdir $(LFE_FILES))))
+BEAM_FILES += $(addprefix ebin/, $(addsuffix .beam,\
+	$(shell grep -h '^.defmodule ' src/*.lfe | sed 's/^.defmodule *\([^ ]*\).*/\1/')))
 
 # Rebuild LFE modules when the Makefile changes.
 $(LFE_FILES): $(MAKEFILE_LIST)


### PR DESCRIPTION
LFE allows creating many modules in a single source file. There is no mandatory correspondence between base names of source files and base names of BEAM files.